### PR TITLE
Multiple Order Resubmit Mutates/Merges Payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.25] - 2015-11-20
+### Fixed
+- Multiple Orders in Order Resubmit Corrupts Payloads
+
 ## [1.6.24] - 2015-11-17
 ### Fixed
 - Credit card expiration data unavailable from order details
@@ -349,6 +353,7 @@ All notable changes to this project will be documented in this file.
 - Gift card PIN is not submitted with the order
 - Product import not importing color descriptions
 
+[1.6.25]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.24...1.6.25
 [1.6.24]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.23...1.6.24
 [1.6.23]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.22...1.6.23
 [1.6.22]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.21...1.6.22


### PR DESCRIPTION
If there are multiple orders to resubmit, the same payload object is recycled to create the secondary order create requests. Instead of being cleared out each time, the payloads are combined and the subsequent messages are broken.