### PR TITLE
DE7600 Order Level Gift Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.30] - 2015-12-03
+### Fixed
+- Order level gift messages should be applicable to ShipGroups
+
 ## [1.6.29] - 2015-12-01
 ### Reverted 1.6.28 incorrect change
 
@@ -368,6 +372,7 @@ All notable changes to this project will be documented in this file.
 - Gift card PIN is not submitted with the order
 - Product import not importing color descriptions
 
+[1.6.30]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.29...1.6.30
 [1.6.29]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.28...1.6.29
 [1.6.28]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.27...1.6.28
 [1.6.27]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.26...1.6.27

--- a/src/app/code/community/EbayEnterprise/Eb2cGiftwrap/Model/Order/Create/Gifting.php
+++ b/src/app/code/community/EbayEnterprise/Eb2cGiftwrap/Model/Order/Create/Gifting.php
@@ -17,36 +17,36 @@ use eBayEnterprise\RetailOrderManagement\Payload\Order\IGifting;
 
 class EbayEnterprise_Eb2cGiftwrap_Model_Order_Create_Gifting
 {
-    /** @var EbayEnterprise_MageLog_Helper_Data */
-    protected $_logger;
     /** @var EbayEnterprise_Eb2cGiftwrap_Helper_Data */
     protected $_helper;
 
     public function __construct($args = array())
     {
         list(
-            $this->_logger,
-            $this->_helper,
+            $this->_helper
         ) = $this->_checkTypes(
-            $this->_nullCoalesce('logger', $args, Mage::helper('ebayenterprise_magelog')),
-            $this->_nullCoalesce('helper', $args, Mage::helper('eb2cgiftwrap'))
+            $this->_nullCoalesce($args, 'helper', Mage::helper('eb2cgiftwrap'))
         );
     }
 
     /**
      * enforce injected types
-     * @param  EbayEnterprise_MageLog_Helper_Data
      * @param  EbayEnterprise_Eb2cGiftwrap_Helper_Data
      * @return array
      */
     protected function _checkTypes(
-        EbayEnterprise_MageLog_Helper_Data $logger,
         EbayEnterprise_Eb2cGiftwrap_Helper_Data $helper
     ) {
-        return array($logger, $helper);
+        return func_get_args();
     }
 
-    protected function _nullCoalesce($key, array $arr, $default = null)
+    /**
+     * @param array
+     * @param string|int
+     * @param mixed
+     * @return mixed
+     */
+    protected function _nullCoalesce(array $arr, $key, $default = null)
     {
         return isset($arr[$key]) ? $arr[$key] : $default;
     }

--- a/src/app/code/community/EbayEnterprise/Eb2cGiftwrap/Test/Model/ObserversTest.php
+++ b/src/app/code/community/EbayEnterprise/Eb2cGiftwrap/Test/Model/ObserversTest.php
@@ -25,17 +25,17 @@ class EbayEnterprise_Eb2cGiftwrap_Test_Model_ObserversTest extends EbayEnterpris
         $doc = Mage::helper('eb2ccore')->getNewDomDocument();
         $doc->loadXML(
             '<ItemMaster>
-				<Item operation_type="Add" gsi_client_id="MAGTNA" catalog_id="14">
-					<ItemId>
-						<ClientItemId>14-77554</ClientItemId>
-					</ItemId>
-					<BaseAttributes>
-						<ItemDescription>Gift Wrap 1</ItemDescription>
-						<ItemType>GiftWrap</ItemType>
-						<TaxCode>78</TaxCode>
-					</BaseAttributes>
-				</Item>
-			</ItemMaster>'
+                <Item operation_type="Add" gsi_client_id="MAGTNA" catalog_id="14">
+                    <ItemId>
+                        <ClientItemId>14-77554</ClientItemId>
+                    </ItemId>
+                    <BaseAttributes>
+                        <ItemDescription>Gift Wrap 1</ItemDescription>
+                        <ItemType>GiftWrap</ItemType>
+                        <TaxCode>78</TaxCode>
+                    </BaseAttributes>
+                </Item>
+            </ItemMaster>'
         );
 
         $feedData = array('event_type' => 'ItemMaster');
@@ -89,5 +89,57 @@ class EbayEnterprise_Eb2cGiftwrap_Test_Model_ObserversTest extends EbayEnterpris
     public function testEventSetup($area, $eventName, $observerClassAlias, $observerMethod)
     {
         $this->_testEventConfig($area, $eventName, $observerClassAlias, $observerMethod);
+    }
+
+    /**
+     * Provide address data, order data, if the address is the primary shipping
+     * address, and the gift message id the address should have after the test.
+     *
+     * @return array
+     */
+    public function provideShipGroupGiftingData()
+    {
+        $giftMessageId = 11;
+        return [
+            // address data, order data, primary shipping, message id
+            [['gift_message_id' => $giftMessageId], [], false, $giftMessageId], // non-primary shipping address, address has message, use address message
+            [['gift_message_id' => $giftMessageId], [], true, $giftMessageId], // primary shipping address, order has no message, use address message
+            [['gift_message_id' => $giftMessageId], ['gift_message_id' => $giftMessageId + 1], false, $giftMessageId], // non-primary shipping address, order has message, use address message
+            [[], ['gift_message_id' => $giftMessageId], true, $giftMessageId], // primary shipping address, order has message, use order message
+        ];
+    }
+
+    /**
+     * @param array
+     * @param array
+     * @param bool
+     * @param int
+     * @dataProvider provideShipGroupGiftingData
+     */
+    public function testHandleEbayEnterpriseOrderCreateShipGroup($addressData, $orderData, $isPrimaryShippingAddress, $giftMessageId)
+    {
+        $address = $this->getModelMockBuilder('sales/order_address')
+            ->setMethods(['isPrimaryShippingAddress'])
+            ->setConstructorArgs([$addressData])
+            ->getMock();
+        $address->method('isPrimaryShippingAddress')->willReturn($isPrimaryShippingAddress);
+
+        $order = Mage::getModel('sales/order', $orderData);
+
+        $payload = $this->getMock('eBayEnterprise\RetailOrderManagement\Payload\Order\IShipGroup');
+
+        $event = new Varien_Event(['address' => $address, 'order' => $order, 'ship_group_payload' => $payload]);
+        $eventObserver = new Varien_Event_Observer(['event' => $event]);
+
+        $orderGifting = $this->getModelMock('eb2cgiftwrap/order_create_gifting', ['injectGifting']);
+        $orderGifting->expects($this->once())
+            ->method('injectGifting')
+            ->with($this->identicalTo($address))
+            ->willReturnSelf();
+
+        $observer = Mage::getModel('eb2cgiftwrap/observers', ['order_gifting' => $orderGifting]);
+        $observer->handleEbayEnterpriseOrderCreateShipGroup($eventObserver);
+
+        $this->assertSame($giftMessageId, $address->getGiftMessageId());
     }
 }


### PR DESCRIPTION
Order level gift messages may be associated with the order or the address. Copies gift message from the order to the primary shipping address when gift message data is associated with the order instead of the address.