### PR TITLE
DE7684 Duplicate Gift Card Message In Cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.31] - 2015-12-04
+### Fixed
+- Duplicate gift card messages in cart
+
 ## [1.6.30] - 2015-12-03
 ### Fixed
 - Order level gift messages should be applicable to ShipGroups
@@ -372,6 +376,7 @@ All notable changes to this project will be documented in this file.
 - Gift card PIN is not submitted with the order
 - Product import not importing color descriptions
 
+[1.6.31]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.30...1.6.31
 [1.6.30]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.29...1.6.30
 [1.6.29]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.28...1.6.29
 [1.6.28]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.27...1.6.28

--- a/src/app/code/community/EbayEnterprise/GiftCard/Model/Adminhtml/Observer.php
+++ b/src/app/code/community/EbayEnterprise/GiftCard/Model/Adminhtml/Observer.php
@@ -13,6 +13,9 @@
  * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
+/**
+ * Observer for gift card events in the admin.
+ */
 class EbayEnterprise_GiftCard_Model_Adminhtml_Observer
 {
     // post data fields for gift cards
@@ -23,20 +26,69 @@ class EbayEnterprise_GiftCard_Model_Adminhtml_Observer
     const ADD_ACTION = 'add';
     const REMOVE_ACTION = 'remove';
     /** @var array post data */
-    protected $_request;
+    protected $request;
     /** @var EbayEnterprise_GiftCard_Model_IContainer */
-    protected $_container;
-    /** @var EbayEnterprise_MageLog_Helper_Data */
-    protected $_logger;
+    protected $container;
     /** @var EbayEnterprise_GiftCard_Helper_Data */
-    protected $_helper;
+    protected $helper;
+    /** @var EbayEnterprise_MageLog_Helper_Data */
+    protected $logger;
+    /** @var EbayEnterprise_MageLog_Helper_Context */
+    protected $logContext;
+    /** @var Mage_Adminhtml_Model_Session_Quote */
+    protected $session;
 
-    public function __construct()
+    /**
+     * @param array
+     */
+    public function __construct(array $args = [])
     {
-        $this->_container = Mage::getModel('ebayenterprise_giftcard/container');
-        $this->_helper = Mage::helper('ebayenterprise_giftcard');
-        $this->_logger = Mage::helper('ebayenterprise_magelog');
+        list(
+            $this->container,
+            $this->helper,
+            $this->logger,
+            $this->logContext,
+            $this->session
+        ) = $this->checkTypes(
+            $this->nullCoalesce($args, 'container', Mage::getModel('ebayenterprise_giftcard/container')),
+            $this->nullCoalesce($args, 'helper', Mage::helper('ebayenterprise_giftcard')),
+            $this->nullCoalesce($args, 'logger', Mage::helper('ebayenterprise_magelog')),
+            $this->nullCoalesce($args, 'log_context', Mage::helper('ebayenterprise_magelog/context')),
+            $this->nullCoalesce($args, 'session', null)
+        );
     }
+
+    /**
+     * @param EbayEnterprise_GiftCard_Model_IContainer
+     * @param EbayEnterprise_GiftCard_Helper_Data
+     * @param EbayEnterprise_MageLog_Helper_Data
+     * @param EbayEnterprise_MageLog_Helper_Context
+     * @param Mage_Adminhtml_Model_Session_Quote|null
+     * @return array
+     */
+    protected function checkTypes(
+        EbayEnterprise_GiftCard_Model_IContainer $container,
+        EbayEnterprise_GiftCard_Helper_Data $helper,
+        EbayEnterprise_MageLog_Helper_Data $logger,
+        EbayEnterprise_MageLog_Helper_Context $logContext,
+        Mage_Adminhtml_Model_Session_Quote $session = null
+    ) {
+        return func_get_args();
+    }
+
+    /**
+     * Return the value at field in array if it exists. Otherwise, use the default value.
+     *
+     * @param  array
+     * @param  string $field Valid array key
+     * @param  mixed
+     * @return mixed
+     */
+    protected function nullCoalesce(array $arr, $field, $default)
+    {
+        return isset($arr[$field]) ? $arr[$field] : $default;
+    }
+
     /**
      * Process post data and set usage of GC into order creation model
      *
@@ -45,86 +97,120 @@ class EbayEnterprise_GiftCard_Model_Adminhtml_Observer
      */
     public function processOrderCreationData(Varien_Event_Observer $observer)
     {
-        if ($this->_helper->getConfigModel()->isEnabled) {
-            $this->_request = $observer->getEvent()->getRequest();
-            list($cardNumber, $pin) = $this->_getCardInfoFromRequest();
+        if ($this->helper->getConfigModel()->isEnabled) {
+            $this->request = $observer->getEvent()->getRequest();
+            list($cardNumber, $pin) = $this->getCardInfoFromRequest();
             if ($cardNumber) {
-                $this->_processCard($cardNumber, $pin);
+                $this->processCard($cardNumber, $pin);
             }
         }
         return $this;
     }
+
     /**
      * Add or remove the gift card, depending on the requested action.
+     *
      * @param string $cardNumber
      * @param string $pin
      * @return self
      */
-    protected function _processCard($cardNumber, $pin)
+    protected function processCard($cardNumber, $pin)
     {
-        if ($this->_isAddRequest()) {
-            $this->_addGiftCard($cardNumber, $pin);
-        } elseif ($this->_isRemoveRequest()) {
-            $this->_removeGiftCard($cardNumber);
+        if ($this->isAddRequest()) {
+            $this->addGiftCard($cardNumber, $pin);
+        } elseif ($this->isRemoveRequest()) {
+            $this->removeGiftCard($cardNumber);
         }
         return $this;
     }
+
     /**
      * Is the gift card action param in the request for an add.
+     *
      * @return boolean
      */
-    protected function _isAddRequest()
+    protected function isAddRequest()
     {
-        return $this->_getPostData(self::ACTION_PARAM, '') === self::ADD_ACTION;
+        return $this->getPostData(self::ACTION_PARAM, '') === self::ADD_ACTION;
     }
+
     /**
      * Is the gift card action param in the request for a remove.
+     *
      * @return boolean
      */
-    protected function _isRemoveRequest()
+    protected function isRemoveRequest()
     {
-        return $this->_getPostData(self::ACTION_PARAM, '') === self::REMOVE_ACTION;
+        return $this->getPostData(self::ACTION_PARAM, '') === self::REMOVE_ACTION;
     }
+
     /**
      * add a giftcard.
+     *
      * @param string $cardNumber
      * @param string $pin
      * @return self
      */
-    public function _addGiftCard($cardNumber, $pin)
+    protected function addGiftCard($cardNumber, $pin)
     {
-        $giftcard = $this->_container->getGiftCard($cardNumber)->setPin($pin);
-        $this->_helper->addGiftCardToOrder($giftcard);
+        $giftcard = $this->container->getGiftCard($cardNumber)->setPin($pin);
+        try {
+            $this->helper->addGiftCardToOrder($giftcard, $this->container);
+            $this->getSession()->addSuccess($this->helper->__(EbayEnterprise_GiftCard_Helper_Data::GIFT_CARD_ADD_SUCCESS, $cardNumber));
+        } catch (EbayEnterprise_GiftCard_Exception $e) {
+            $this->getSession()->addError($this->helper->__($e->getMessage()));
+            $this->logger->debug('Failed to add gift card to admin order. See exception log for more details.', $this->logContext->getMetaData(__CLASS__, ['exception_message' => $e->getMessage()]));
+            $this->logger->logException($e, $this->logContext->getMetaData(__CLASS__, [], $e));
+        }
         return $this;
     }
+
     /**
      * remove a giftcard.
+     *
      * @param string $cardNumber
      * @return self
      */
-    protected function _removeGiftCard($cardNumber)
+    protected function removeGiftCard($cardNumber)
     {
-        $giftcard = $this->_container->getGiftCard($cardNumber);
-        $this->_container->removeGiftCard($giftcard);
+        $giftcard = $this->container->getGiftCard($cardNumber);
+        $this->container->removeGiftCard($giftcard);
         return $this;
     }
+
     /**
      * Extract the card number and pin from the request. If either is not present,
      * will return an empty string for that value.
+     *
      * @return string[] Tuple of card number and pin
      */
-    protected function _getCardInfoFromRequest()
+    protected function getCardInfoFromRequest()
     {
-        return array($this->_getPostData(self::CARD_NUMBER_PARAM, ''), $this->_getPostData(self::CARD_PIN_PARAM, ''));
+        return [$this->getPostData(self::CARD_NUMBER_PARAM, ''), $this->getPostData(self::CARD_PIN_PARAM, '')];
     }
+
     /**
      * Get post data from the request. If not set, return the default value.
+     *
      * @param string|int $field
      * @param string $default
      * @return string
      */
-    protected function _getPostData($field, $default)
+    protected function getPostData($field, $default)
     {
-        return isset($this->_request[$field]) ? $this->_request[$field] : $default;
+        return $this->nullCoalesce($this->request, $field, $default);
+    }
+
+    /**
+     * Get the adminhtml quote session.
+     *
+     * @return Mage_Adminhtml_Model_Session_Quote
+     */
+    protected function getSession()
+    {
+        if (!$this->session) {
+            $this->session = Mage::getSingleton('adminhtml/session_quote');
+        }
+        return $this->session;
     }
 }

--- a/src/app/code/community/EbayEnterprise/GiftCard/Test/Helper/DataTest.php
+++ b/src/app/code/community/EbayEnterprise/GiftCard/Test/Helper/DataTest.php
@@ -15,17 +15,37 @@
 
 class EbayEnterprise_GiftCard_Test_Helper_DataTest extends EbayEnterprise_Eb2cCore_Test_Base
 {
-    /** @var EbayEnterprise_Eb2cCore_Helper_Data $coreHelper */
-    protected $coreHelper;
     /** @var EbayEnterprise_GiftCard_Helper_Data $giftCardHelper */
     protected $giftCardHelper;
+    /** @var EbayEnterprise_GiftCard_Model_Session (mock) */
+    protected $session;
+    /** @var SplObjectStorage */
+    protected $giftCardStorage;
+    /** @var EbayEnterprise_Giftcard_Model_Container */
+    protected $giftCardContainer;
 
     public function setUp()
     {
         parent::setUp();
-        $this->coreHelper = Mage::helper('eb2ccore');
+
+        $this->giftCardStorage = new SplObjectStorage;
+
+        $this->session = $this->getModelMockBuilder('ebayenterprise_giftcard/session')
+            ->disableOriginalConstructor()
+            ->setMethods(null)
+            ->getMock();
+
+        $this->giftCardContainer = Mage::getModel(
+            'ebayenterprise_giftcard/container',
+            [
+                'gift_card_storage' => $this->giftCardStorage,
+                'session' => $this->session
+            ]
+        );
+
         $this->giftCardHelper = Mage::helper('ebayenterprise_giftcard');
     }
+
     /**
      * Test adding a gift card to the container. Success path should result in
      * the card being in the container after having the card's balance checked.
@@ -36,21 +56,23 @@ class EbayEnterprise_GiftCard_Test_Helper_DataTest extends EbayEnterprise_Eb2cCo
         $this->_replaceSession('ebayenterprise_giftcard/session');
 
         $cardNumber = '1111222233334444';
+        $pin = '1234';
         $card = $this->getModelMock('ebayenterprise_giftcard/giftcard', array('checkBalance'));
-        $card->setBalanceAmount(25.00)->setCardNumber($cardNumber);
+        $card->setBalanceAmount(25.00)->setCardNumber($cardNumber)->setPin($pin);
         $card->expects($this->once())
             ->method('checkBalance')
             ->will($this->returnSelf());
 
         // attempt to add the gift card to the order
-        $this->giftCardHelper->addGiftCardToOrder($card);
+        $this->giftCardHelper->addGiftCardToOrder($card, $this->giftCardContainer);
 
         // matching card (has same data) should be returned from the container
         $this->assertSame(
-            $cardNumber,
-            Mage::getModel('ebayenterprise_giftcard/container')->getGiftCard($cardNumber)->getCardNumber()
+            $pin,
+            $this->giftCardContainer->getGiftCard($cardNumber)->getPin()
         );
     }
+
     /**
      * Test that gift cards with zero balance should not be added to the cart/container.
      */
@@ -58,26 +80,37 @@ class EbayEnterprise_GiftCard_Test_Helper_DataTest extends EbayEnterprise_Eb2cCo
     {
         // replace session used by the gift card container - prevents headers already sent error from session
         $this->_replaceSession('ebayenterprise_giftcard/session');
-        $checkoutSession = $this->_replaceSession('checkout/session');
 
         $cardNumber = '1111222233334444';
+        $pin = '1234';
         $card = $this->getModelMock('ebayenterprise_giftcard/giftcard', array('checkBalance'));
-        $card->setBalanceAmount(0.00)->setCardNumber($cardNumber);
+        $card->setBalanceAmount(0.00)->setCardNumber($cardNumber)->setPin($pin);
         $card->expects($this->once())
             ->method('checkBalance')
             ->will($this->returnSelf());
 
-        // attempt to add the gift card to the order
-        $this->giftCardHelper->addGiftCardToOrder($card);
+        // Need custom exception testing: want to make sure that an expected
+        // exception is thrown but also need to test some post conditions,
+        // specifically that the gift cards wasn't added to the container. Catch
+        // the exception thrown and validate that the expected exception was
+        // thrown and caught in the test.
+        $thrownException = null;
+        try {
+            // attempt to add the gift card to the order
+            $this->giftCardHelper->addGiftCardToOrder($card, $this->giftCardContainer);
+        } catch (EbayEnterprise_GiftCard_Exception $e) {
+            $thrownException = $e;
+        }
 
-        // zero balance gift card should result in new error message in the checkout session
-        $this->assertCount(1, $checkoutSession->getMessages()->getErrors());
+        $this->assertInstanceOf('EbayEnterprise_GiftCard_Exception', $thrownException);
+
         // card should not have been added to the container - get gift card with same number will return new gift card instance
         $this->assertNotSame(
-            $card,
-            Mage::getModel('ebayenterprise_giftcard/container')->getGiftCard($cardNumber)
+            $card->getPin(),
+            $this->giftCardContainer->getGiftCard($cardNumber)->getPin()
         );
     }
+
     /**
      * Test that when a balance check fails, gift cards are not added to the cart/container.
      */
@@ -85,24 +118,34 @@ class EbayEnterprise_GiftCard_Test_Helper_DataTest extends EbayEnterprise_Eb2cCo
     {
         // replace session used by the gift card container - prevents headers already sent error from session
         $this->_replaceSession('ebayenterprise_giftcard/session');
-        $checkoutSession = $this->_replaceSession('checkout/session');
 
         $cardNumber = '1111222233334444';
+        $pin = '1234';
         $card = $this->getModelMock('ebayenterprise_giftcard/giftcard', array('checkBalance'));
-        $card->setBalanceAmount(50.00)->setCardNumber($cardNumber);
+        $card->setBalanceAmount(50.00)->setCardNumber($cardNumber)->setPin($pin);
         $card->expects($this->once())
             ->method('checkBalance')
             ->will($this->throwException(new EbayEnterprise_GiftCard_Exception));
 
-        // attempt to add the gift card to the order
-        $this->giftCardHelper->addGiftCardToOrder($card);
+        // Need custom exception testing: want to make sure that an expected
+        // exception is thrown but also need to test some post conditions,
+        // specifically that the gift cards wasn't added to the container. Catch
+        // the exception thrown and validate that the expected exception was
+        // thrown and caught in the test.
+        $thrownException = null;
+        try {
+            // attempt to add the gift card to the order
+            $this->giftCardHelper->addGiftCardToOrder($card, $this->giftCardContainer);
+        } catch (EbayEnterprise_GiftCard_Exception $e) {
+            $thrownException = $e;
+        }
 
-        // gift card balance check failures should result in new error message
-        $this->assertCount(1, $checkoutSession->getMessages()->getErrors());
+        $this->assertInstanceOf('EbayEnterprise_GiftCard_Exception', $thrownException);
+
         // card should not have been added to the container - get gift card with same number will return new gift card instance
         $this->assertNotSame(
-            $card,
-            Mage::getModel('ebayenterprise_giftcard/container')->getGiftCard($cardNumber)
+            $card->getPin(),
+            $this->giftCardContainer->getGiftCard($cardNumber)->getPin()
         );
     }
 }

--- a/src/app/code/community/EbayEnterprise/GiftCard/Test/Model/Adminhtml/ObserverTest.php
+++ b/src/app/code/community/EbayEnterprise/GiftCard/Test/Model/Adminhtml/ObserverTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright (c) 2013-2014 eBay Enterprise, Inc.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @copyright   Copyright (c) 2013-2014 eBay Enterprise, Inc. (http://www.ebayenterprise.com/)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Unit tests for @see EbayEnterprise_GiftCard_Model_Adminhtml_Observer
+ */
+class EbayEnterprise_GiftCard_Test_Model_Adminhtml_ObserverTest extends EbayEnterprise_Eb2cCore_Test_Base
+{
+    /** @var EbayEnterprise_GiftCard_Model_IContainer (mock) */
+    protected $container;
+    /** @var EbayEnterprise_GiftCard_Model_Giftcard (mock) */
+    protected $giftCard;
+    /** @var EbayEnterprise_GiftCard_Helper_Data (mock) */
+    protected $helper;
+    /** @var EbayEnterprise_GiftCard_Model_Adminhtml_Observer */
+    protected $observer;
+
+    public function setUp()
+    {
+        $this->container = $this->getMockForAbstractClass('EbayEnterprise_GiftCard_Model_IContainer');
+
+        $this->giftCard = $this->getModelMock('ebayenterprise_giftcard/giftcard', ['setPin']);
+
+        $this->helper = $this->getHelperMock('ebayenterprise_giftcard', ['addGiftCardToOrder', '__']);
+        $this->helper->method('__')->willReturnArgument(0);
+
+        $this->session = $this->getModelMockBuilder('adminhtml/session_quote')
+            ->setMethods(null)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $logContext = $this->getHelperMock('ebayenterprise_magelog/context', ['getMetaData']);
+        $logContext->method('getMetaData')->willReturn([]);
+
+        $this->observer = Mage::getModel(
+            'ebayenterprise_giftcard/adminhtml_observer',
+            [
+                'container' => $this->container,
+                'helper' => $this->helper,
+                'log_context' => $logContext,
+                'session' => $this->session
+            ]
+        );
+    }
+
+    /**
+     * When adding a gift card to the order, the card should be retrieved from
+     * the container by card number, have the PIN set on the card and finally
+     * be added to the order.
+     *
+     * @param bool
+     * @dataProvider provideTrueFalse
+     */
+    public function testAddGiftCard($success)
+    {
+        $cardNumber = '1111111111111111';
+        $pin = '1234';
+
+        $this->container
+            ->method('getGiftCard')
+            ->with($cardNumber)
+            ->willReturn($this->giftCard);
+        // Pin must be set on the gift card to be added.
+        $this->giftCard->expects($this->once())
+            ->method('setPin')
+            ->with($this->identicalTo($pin))
+            ->willReturnSelf();
+
+        // Helper should be used to add the gift card to the order. When gift
+        // card is successfully added, it should return self. Otherwise, it will
+        // thrown an exception.
+        $addGiftCardInvoker = $this->helper->expects($this->once())
+            ->method('addGiftCardToOrder')
+            ->with($this->identicalTo($this->giftCard), $this->identicalTo($this->container));
+
+        if ($success) {
+            $addGiftCardInvoker->willReturnSelf();
+        } else {
+            $addGiftCardInvoker->willThrowException(new EbayEnterprise_GiftCard_Exception('TEST EXCEPTION: ' . __METHOD__));
+        }
+
+        $this->assertSame(
+            $this->observer,
+            EcomDev_Utils_Reflection::invokeRestrictedMethod($this->observer, 'addGiftCard', [$cardNumber, $pin])
+        );
+
+        // When gift card added successfully, expect a success message to have
+        // been added to the session. When unsuccessful, should add an error
+        // message to the session.
+        $expectMessageType = $success ? Mage_Core_Model_Message::SUCCESS : Mage_Core_Model_Message::ERROR;
+        $this->assertCount(1, $this->session->getMessages()->getItemsByType($expectMessageType));
+    }
+}

--- a/src/app/code/community/EbayEnterprise/GiftCard/controllers/CartController.php
+++ b/src/app/code/community/EbayEnterprise/GiftCard/controllers/CartController.php
@@ -17,31 +17,49 @@ class EbayEnterprise_GiftCard_CartController extends EbayEnterprise_GiftCard_Con
 {
     //** @see EbayEnterprise_GiftCard_Controller_Abstract */
     const REDIRECT_PATH = 'checkout/cart/';
-    const GIFT_CARD_ADD_SUCCESS = 'EbayEnterprise_GiftCard_Cart_Add_Success';
-    const GIFT_CARD_REMOVE_SUCCESS = 'EbayEnterprise_GiftCard_Cart_Remove_Success';
+
     /**
      * add a giftcard to the cart.
      */
     public function addAction()
     {
         list($cardNumber, $pin) = $this->_getCardInfoFromRequest();
+
         if ($cardNumber) {
+
+            $container = $this->_getContainer();
             // try a balance request.
-            $giftcard = $this->_getContainer()->getGiftCard($cardNumber)->setPin($pin);
-            $this->_helper->addGiftCardToOrder($giftcard);
-            $this->_getCheckoutSession()->addSuccess($this->_helper->__(self::GIFT_CARD_ADD_SUCCESS, $giftcard->getCardNumber()));
+            $giftcard = $container->getGiftCard($cardNumber)->setPin($pin);
+
+            try {
+
+                $this->_helper->addGiftCardToOrder($giftcard, $container);
+                $this->_getCheckoutSession()
+                    ->addSuccess($this->_helper->__(EbayEnterprise_GiftCard_Helper_Data::GIFT_CARD_ADD_SUCCESS, $giftcard->getCardNumber()));
+
+            } catch (EbayEnterprise_GiftCard_Exception $e) {
+
+                $this->_getCheckoutSession()->addError($this->_helper->__($e->getMessage()));
+
+            }
         }
         $this->_redirect(static::REDIRECT_PATH);
     }
+
     /**
      * remove a giftcard from the cart.
      */
     public function removeAction()
     {
         list($cardNumber) = $this->_getCardInfoFromRequest();
+
         $giftcard = $this->_getContainer()->getGiftCard($cardNumber);
+
         $this->_getContainer()->removeGiftCard($giftcard);
-        $this->_getCheckoutSession()->addSuccess($this->_helper->__(self::GIFT_CARD_REMOVE_SUCCESS, $giftcard->getCardNumber()));
+
+        $this->_getCheckoutSession()
+            ->addSuccess($this->_helper->__(EbayEnterprise_GiftCard_Helper_Data::GIFT_CARD_REMOVE_SUCCESS, $giftcard->getCardNumber()));
+
         $this->_redirect(static::REDIRECT_PATH);
     }
 }


### PR DESCRIPTION
When applying a gift card, when the gift card is invalid or otherwise
fails to be added to cart, two messages are displayed to the user, a
failure message and a success message. Only the failure message should
be displayed when the gift card cannot be added to card.