### PR TITLE
Order Totals Missing from New Order Email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.37] - 2016-01-??
+### Fixed
+- Order totals missing from new order email from Magento
+
 ## [1.6.36] - 2016-01-14
 ### Fixed
 - Persist Credit Card in Backend Order Create with CSE Enabled
@@ -397,7 +401,8 @@ All notable changes to this project will be documented in this file.
 - Gift card PIN is not submitted with the order
 - Product import not importing color descriptions
 
-[1.6.35]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.35...1.6.36
+[1.6.37]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.36...1.6.37
+[1.6.36]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.35...1.6.36
 [1.6.35]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.34...1.6.35
 [1.6.34]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.33...1.6.34
 [1.6.33]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.32...1.6.33

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [1.6.37] - 2016-01-??
+## [1.6.37] - 2016-01-15
 ### Fixed
 - Order totals missing from new order email from Magento
+- Discount totals not transferred to new orders
 
 ## [1.6.36] - 2016-01-14
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         { "name": "Michael Phang", "email": "mphang@ebay.com" },
         { "name": "Mike West", "email": "micwest@ebay.com" },
         { "name": "Reginald Gabriel", "email": "rgabriel@ebay.com" },
+        { "name": "Ryan Tulino", "email": "rtulino@ebay.com" },
         { "name": "Scott van Brug", "email": "svanbrug@ebay.com" }
     ],
     "type": "magento-module",

--- a/src/app/code/community/EbayEnterprise/GiftCard/Block/Sales/Order/Total.php
+++ b/src/app/code/community/EbayEnterprise/GiftCard/Block/Sales/Order/Total.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Copyright (c) 2013-2014 eBay Enterprise, Inc.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @copyright   Copyright (c) 2013-2014 eBay Enterprise, Inc. (http://www.ebayenterprise.com/)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Block for rendering eBay Enterprise gift card totals for email templates.
+ */
+class EbayEnterprise_GiftCard_Block_Sales_Order_Total extends Mage_Core_Block_Template
+{
+    const TOTAL_CODE = 'ebayenterprise_giftcard';
+    const TOTAL_LABEL = 'EbayEnterprise_GiftCard_Order_Total_Label';
+
+    /** @var EbayEnterprise_GiftCard_Model_Container */
+    protected $giftcardContainer;
+    /** @var EbayEnterprise_GiftCard_Helper_Data */
+    protected $helper;
+
+    public function __construct(array $args = [])
+    {
+        list(
+            $this->giftcardContainer,
+            $this->helper
+        ) = $this->checkTypes(
+            $this->nullCoalesce($args, 'giftcard_container', Mage::getModel('ebayenterprise_giftcard/container')),
+            $this->nullCoalesce($args, 'helper', Mage::helper('ebayenterprise_giftcard'))
+        );
+        parent::__construct($args);
+    }
+
+    /**
+     * Enforce type checks on construct args array.
+     *
+     * @param EbayEnterprise_GiftCard_Model_Container
+     * @param EbayEnterprise_GiftCard_Helper_Data
+     * @return array
+     */
+    protected function checkTypes(
+        EbayEnterprise_GiftCard_Model_Container $giftcardContainer,
+        EbayEnterprise_GiftCard_Helper_Data $helper
+    ) {
+        return func_get_args();
+    }
+
+    /**
+     * Fill in default values.
+     *
+     * @param array
+     * @param string
+     * @param mixed
+     * @return mixed
+     */
+    protected function nullCoalesce(array $arr, $key, $default)
+    {
+        return isset($arr[$key]) ? $arr[$key] : $default;
+    }
+
+    /**
+     * Get the current order model.
+     *
+     * @return Mage_Sales_Model_Order
+     */
+    public function getOrder()
+    {
+        return $this->getParentBlock()->getOrder();
+    }
+
+    /**
+     * Register gift card totals with the order totals block.
+     *
+     * @return self
+     */
+    public function initTotals()
+    {
+        $total = new Varien_Object([
+            'code' => self::TOTAL_CODE,
+            // Using a block name instead of just adding values so a template
+            // can be used to render the gift card totals.
+            'block_name' => $this->getNameInLayout(),
+            'label' => $this->helper->__(self::TOTAL_LABEL),
+        ]);
+        $this->getParentBlock()->addTotalBefore($total, ['customerbalance', 'grand_total']);
+        return $this;
+    }
+
+    /**
+     * Get all gift cards redeemed for the order.
+     *
+     * @return SPLObjectStorage
+     */
+    public function getGiftCards()
+    {
+        return $this->giftcardContainer->getRedeemedGiftCards();
+    }
+
+    /**
+     * Get the label to use for a gift card in the totals.
+     *
+     * @param EbayEnterprise_GiftCard_Model_Giftcard
+     * @return string
+     */
+    public function getCardLabel(EbayEnterprise_GiftCard_Model_Giftcard $card)
+    {
+        return $this->__(self::TOTAL_LABEL, $card->getCardNumber());
+    }
+
+    /**
+     * Get the value of the gift card to display in the totals.
+     *
+     * @param EbayEnterprise_GiftCard_Model_Giftcard
+     * @return string
+     */
+    public function getCardValue(EbayEnterprise_GiftCard_Model_Giftcard $card)
+    {
+        return $this->getOrder()->formatPrice($card->getAmountRedeemed() * -1);
+    }
+
+    /**
+     * Attributes to add to the html element wrapping the total's label.
+     *
+     * @return string
+     */
+    public function getLabelProperties()
+    {
+        return $this->getParentBlock()->getLabelProperties();
+    }
+
+    /**
+     * Attributes to add to the html element wrapping the total's value.
+     *
+     * @return string
+     */
+    public function getValueProperties()
+    {
+        return $this->getParentBlock()->getValueProperties();
+    }
+}

--- a/src/app/code/community/EbayEnterprise/Multishipping/Test/Model/ObserverTest.php
+++ b/src/app/code/community/EbayEnterprise/Multishipping/Test/Model/ObserverTest.php
@@ -31,4 +31,50 @@ class EbayEnterprise_Multishipping_Test_Model_ObserverTest extends EcomDev_PHPUn
         $observer = Mage::getModel('ebayenterprise_multishipping/observer');
         $observer->handleSalesOrderSaveBefore($eventObserver);
     }
+
+    /**
+     * When converting a quote to an order, discount data from quote addresses
+     * needs to bubble up to the order.
+     */
+    public function testHandleSalesConvertQuoteToOrder()
+    {
+        $shipAddressDiscountAmt = 5.00;
+        $shipAddressBaseDiscountAmt = 7.00;
+        $altShipAddressDiscountAmt = 3.00;
+        $altShipAddressBaseDiscountAmt = 5.00;
+        $discountTotal = 8.00;
+        $discountBaseTotal = 12.00;
+        $discountDescription = 'Discount Description';
+        $altDiscountDescription = 'Alt Discount Description';
+
+        $order = Mage::getModel('sales/order');
+        $quote = $this->getModelMock('sales/quote', ['getAllAddresses']);
+        $shippingAddress = Mage::getModel(
+            'sales/quote_address',
+            ['discount_amount' => $shipAddressDiscountAmt, 'base_discount_amount' => $shipAddressBaseDiscountAmt, 'discount_description' => $discountDescription]
+        );
+        $altShippingAddress = Mage::getModel(
+            'sales/quote_address',
+            ['discount_amount' => $altShipAddressDiscountAmt, 'base_discount_amount' => $altShipAddressBaseDiscountAmt, 'discount_description' => $altDiscountDescription]
+        );
+        $billingAddress = Mage::getModel('sales/quote_address', []);
+
+        $quote->method('getAllAddresses')->willReturn([$shippingAddress, $altShippingAddress, $billingAddress]);
+
+        $event = new Varien_Event(['order' => $order, 'quote' => $quote]);
+        $eventObserver = new Varien_Event_Observer(['event' => $event]);
+
+        $observer = Mage::getModel('ebayenterprise_multishipping/observer');
+        $observer->handleSalesConvertQuoteToOrder($eventObserver);
+
+        $this->assertSame($discountTotal, $order->getDiscountAmount());
+        $this->assertSame($discountBaseTotal, $order->getBaseDiscountAmount());
+        // Only the first discount description encountered should be used for the
+        // order. If there are multiple discount descriptions, in OOTB Magento,
+        // they will always be the same (here "discount" really only means coupons).
+        // In the case that they are, for some reason, different on different addresses,
+        // the order still only takes a single discount description so only
+        // the first should be used.
+        $this->assertSame($discountDescription, $order->getDiscountDescription());
+    }
 }

--- a/src/app/code/community/EbayEnterprise/Multishipping/etc/config.xml
+++ b/src/app/code/community/EbayEnterprise/Multishipping/etc/config.xml
@@ -314,6 +314,14 @@ http://opensource.org/licenses/osl-3.0.php
                     </collect_address_shipment_totals>
                 </observers>
             </sales_order_save_before>
+            <sales_convert_quote_to_order>
+                <observers>
+                    <collect_order_discount_amounts>
+                        <class>ebayenterprise_multishipping/observer</class>
+                        <method>handleSalesConvertQuoteToOrder</method>
+                    </collect_order_discount_amounts>
+                </observers>
+            </sales_convert_quote_to_order>
         </events>
     </global>
     <default>

--- a/src/app/code/community/EbayEnterprise/Tax/Block/Sales/Order/Tax.php
+++ b/src/app/code/community/EbayEnterprise/Tax/Block/Sales/Order/Tax.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Copyright (c) 2013-2014 eBay Enterprise, Inc.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @copyright   Copyright (c) 2013-2014 eBay Enterprise, Inc. (http://www.ebayenterprise.com/)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Block for rendering eBay Enterprise tax data for email templates.
+ */
+class EbayEnterprise_Tax_Block_Sales_Order_Tax extends Mage_Core_Block_Abstract
+{
+    const TAX_LABEL = 'EbayEnterprise_Tax_Order_Total_Tax_Title';
+    const TOTAL_CODE = 'ebayenterprise_tax';
+
+    /** @var EbayEnterprise_Tax_Model_Collector */
+    protected $taxCollector;
+    /** @var EbayEnterprise_Tax_Helper_Data */
+    protected $helper;
+
+    /**
+     * @param array May contain:
+     *              - tax_collector => EbayEnterprise_Tax_Model_Collector
+     */
+    public function __construct(array $args = [])
+    {
+        list(
+            $this->taxCollector,
+            $this->helper
+        ) = $this->checkTypes(
+            $this->nullCoalesce($args, 'tax_collector', Mage::getModel('ebayenterprise_tax/collector')),
+            $this->nullCoalesce($args, 'helper', Mage::helper('ebayenterprise_tax'))
+        );
+        parent::__construct($args);
+    }
+
+    /**
+     * Enforce type checks on construct args array.
+     *
+     * @param EbayEnterprise_Tax_Model_Collector
+     * @param EbayEnterprise_Tax_Helper_Data
+     * @return array
+     */
+    protected function checkTypes(
+        EbayEnterprise_Tax_Model_Collector $taxCollector,
+        EbayEnterprise_Tax_Helper_Data $helper
+    ) {
+        return func_get_args();
+    }
+
+    /**
+     * Fill in default values.
+     *
+     * @param array
+     * @param string
+     * @param mixed
+     * @return mixed
+     */
+    protected function nullCoalesce(array $arr, $key, $default)
+    {
+        return isset($arr[$key]) ? $arr[$key] : $default;
+    }
+
+    /**
+     * Add totals for collected taxes to the parent block. Totals added to the
+     * parent will be displayed with order totals.
+     *
+     * @return self
+     */
+    public function initTotals()
+    {
+        $parent = $this->getParentBlock();
+
+        $taxAmount = $this->totalTaxAmount();
+        $parent->addTotal(
+            new Varien_Object([
+                'code' => self::TOTAL_CODE,
+                'value' => $taxAmount,
+                'base_value' => $taxAmount,
+                'label' => $this->helper->__(self::TAX_LABEL),
+            ]),
+            'discount'
+        );
+
+        return $this;
+    }
+
+    /**
+     * Total all taxes associated with the current order.
+     *
+     * @return float
+     */
+    protected function totalTaxAmount()
+    {
+        $records = array_reduce($this->taxCollector->getTaxRecords(), function ($total, $item) { return $total + $item->getCalculatedTax(); }, 0.00);
+        $duties = array_reduce($this->taxCollector->getTaxDuties(), function ($total, $item) { return $total + $item->getAmount(); }, 0.00);
+        $fees = array_reduce($this->taxCollector->getTaxFees(), function ($total, $item) { return $total + $item->getAmount(); }, 0.00);
+
+        return $records + $duties + $fees;
+    }
+}

--- a/src/app/code/community/EbayEnterprise/Tax/etc/config.xml
+++ b/src/app/code/community/EbayEnterprise/Tax/etc/config.xml
@@ -19,6 +19,11 @@ http://opensource.org/licenses/osl-3.0.php
         </EbayEnterprise_Tax>
     </modules>
     <global>
+        <blocks>
+            <ebayenterprise_tax>
+                <class>EbayEnterprise_Tax_Block</class>
+            </ebayenterprise_tax>
+        </blocks>
         <models>
             <ebayenterprise_tax>
                 <class>EbayEnterprise_Tax_Model</class>
@@ -105,6 +110,13 @@ http://opensource.org/licenses/osl-3.0.php
                 </EbayEnterprise_Tax>
             </modules>
         </translate>
+        <layout>
+            <updates>
+                <ebayenterprise_tax>
+                    <file>ebayenterprise_tax.xml</file>
+                </ebayenterprise_tax>
+            </updates>
+        </layout>
     </frontend>
     <adminhtml>
         <translate>

--- a/src/app/design/frontend/base/default/layout/ebayenterprise_giftcard.xml
+++ b/src/app/design/frontend/base/default/layout/ebayenterprise_giftcard.xml
@@ -65,4 +65,10 @@ http://opensource.org/licenses/osl-3.0.php
             <block name="ebayenterprise_giftcard_onepage_payment_additional" template="ebayenterprise_giftcard/onepage/payment/additional.phtml" type="ebayenterprise_giftcard/checkout_onepage_payment_additional"/>
         </reference>
     </checkout_onepage_paymentmethod>
+    <!-- New order email totals -->
+    <sales_email_order_items>
+        <reference name="order_totals">
+            <block type="ebayenterprise_giftcard/sales_order_total" name="ebayenterprise_giftcard_total" template="ebayenterprise_giftcard/order/total.phtml" />
+        </reference>
+    </sales_email_order_items>
 </layout>

--- a/src/app/design/frontend/base/default/layout/ebayenterprise_tax.xml
+++ b/src/app/design/frontend/base/default/layout/ebayenterprise_tax.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (c) 2013-2014 eBay Enterprise, Inc.
+
+NOTICE OF LICENSE
+
+This source file is subject to the Open Software License (OSL 3.0)
+that is bundled with this package in the file LICENSE.md.
+It is also available through the world-wide-web at this URL:
+http://opensource.org/licenses/osl-3.0.php
+
+@copyright   Copyright (c) 2013-2014 eBay Enterprise, Inc. (http://www.ebayenterprise.com/)
+@license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+-->
+<layout version="0.1.0">
+    <!-- New order email totals -->
+    <sales_email_order_items>
+        <reference name="order_totals">
+            <block type="ebayenterprise_tax/sales_order_tax" name="ebayenterprise_tax_total" />
+        </reference>
+    </sales_email_order_items>
+</layout>

--- a/src/app/design/frontend/base/default/template/ebayenterprise_giftcard/order/total.phtml
+++ b/src/app/design/frontend/base/default/template/ebayenterprise_giftcard/order/total.phtml
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (c) 2013-2014 eBay Enterprise, Inc.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @copyright   Copyright (c) 2013-2014 eBay Enterprise, Inc. (http://www.ebayenterprise.com/)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+?>
+
+<?php
+/** @var EbayEnterprise_GiftCard_Block_Sales_Order_Total $this */
+
+$cards  = $this->getGiftCards();
+
+foreach ($cards as $card): ?>
+<tr>
+    <td <?php echo $this->getLabelProperties() ?>>
+        <?php echo $this->getCardLabel($card) ?>
+    </td>
+    <td <?php echo $this->getValueProperties() ?>>
+        <?php echo $this->getCardValue($card) ?>
+    </td>
+</tr>
+<?php endforeach; ?>

--- a/src/app/locale/en_US/EbayEnterprise_GiftCard.csv
+++ b/src/app/locale/en_US/EbayEnterprise_GiftCard.csv
@@ -18,3 +18,4 @@
 "EbayEnterprise_GiftCard_Form_Check_Balance_Button_Label", "Check Gift Card status and balance"
 "EbayEnterprise_GiftCard_%s", "eBay Enterprise Gift Cards"
 "EbayEnterprise_GiftCard_Zero_Balance_Card", "Gift card (%s) has no available balance."
+"EbayEnterprise_GiftCard_Order_Total_Label", "Gift Card (%s)"

--- a/src/app/locale/en_US/EbayEnterprise_Tax.csv
+++ b/src/app/locale/en_US/EbayEnterprise_Tax.csv
@@ -1,2 +1,3 @@
 "EbayEnterprise_Tax_Total_Quote_Address_Tax_Title", "Tax"
+"EbayEnterprise_Tax_Order_Total_Tax_Title", "Tax"
 "EbayEnterprise_Tax_Request_Failed", "Unable to collect taxes."


### PR DESCRIPTION
Add totals for tax and gift cards added by the extension to the new order email. These totals are not persisted in the DB so need to be pulled from session while creating the order.

Discount totals were missing due to not being transferred from quote addresses to the order while creating a new order. Adds an observer that gets triggered while converting the quote to an order that will transfer discount data from the quote addresses to the order.