### PR TITLE
ENF-67 Pass The Tokenize GC PAN to OCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.40] - 2016-01-21
+### Fixed
+- Send the tokenized giftcard pan in order create request payload
+
 ## [1.6.39] - 2016-01-19
 ### Fixed
 - Admin order create totals not updating properly
@@ -411,6 +415,7 @@ All notable changes to this project will be documented in this file.
 - Gift card PIN is not submitted with the order
 - Product import not importing color descriptions
 
+[1.6.40]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.39...1.6.40
 [1.6.39]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.38...1.6.39
 [1.6.38]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.37...1.6.38
 [1.6.37]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.36...1.6.37

--- a/src/app/code/community/EbayEnterprise/GiftCard/Model/Order/Create/Payment.php
+++ b/src/app/code/community/EbayEnterprise/GiftCard/Model/Order/Create/Payment.php
@@ -58,8 +58,8 @@ class EbayEnterprise_Giftcard_Model_Order_Create_Payment
                 // payment context
                 ->setOrderId($order->getIncrementId())
                 ->setTenderType($giftcard->getTenderType())
-                ->setAccountUniqueId($giftcard->getCardNumber())
-                ->setPanIsToken((bool) $giftcard->getPanIsToken())
+                ->setAccountUniqueId($this->getGcPan($giftcard))
+                ->setPanIsToken($this->isPanTokenize($giftcard))
                 // payment data
                 ->setCreateTimestamp($giftcard->getRedeemedAt())
                 ->setAmount($giftcard->getAmountRedeemed())
@@ -75,5 +75,28 @@ class EbayEnterprise_Giftcard_Model_Order_Create_Payment
     protected function _nullCoalesce($key, array $args, $default)
     {
         return isset($args[$key]) ? $args[$key] : $default;
+    }
+
+    /**
+     * Determine if the PAN in the giftcard is tokenized.
+     *
+     * @param EbayEnterprise_GiftCard_Model_IGiftcard
+     * @return bool
+     */
+    protected function isPanTokenize(EbayEnterprise_GiftCard_Model_IGiftcard $giftcard)
+    {
+        return !is_null($giftcard->getTokenizedCardNumber());
+    }
+
+    /**
+     * Get the Giftcard PAN. Return the tokenized pan if it is tokenized otherwise
+     * return the raw PAN.
+     *
+     * @param EbayEnterprise_GiftCard_Model_IGiftcard
+     * @return bool
+     */
+    protected function getGcPan(EbayEnterprise_GiftCard_Model_IGiftcard $giftcard)
+    {
+        return $this->isPanTokenize($giftcard) ? $giftcard->getTokenizedCardNumber() : $giftcard->getCardNumber();
     }
 }


### PR DESCRIPTION
The Raw GC Number is always being passed to Order Create Payload.
Added Logic to ensure that tokenized PAN is passed to OCR Payload.