### PR TITLE
ENF-53 Clear Gift Cards On Cancel Admin Order Create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [1.6.40] - 2016-01-21
 ### Fixed
 - Send the tokenized giftcard pan in order create request payload
+- Applied gift cards carry over from cancelled order create to next order in admin
 
 ## [1.6.39] - 2016-01-19
 ### Fixed

--- a/src/app/code/community/EbayEnterprise/GiftCard/etc/config.xml
+++ b/src/app/code/community/EbayEnterprise/GiftCard/etc/config.xml
@@ -162,6 +162,24 @@ http://opensource.org/licenses/osl-3.0.php
                     </ebayenterprise_giftcard_process_order_create_data>
                 </observers>
             </adminhtml_sales_order_create_process_data>
+            <controller_action_postdispatch_adminhtml_sales_order_create_cancel>
+                <observers>
+                    <ebayenterprise_giftcard_empty_container_cancel_order_create>
+                        <type>model</type>
+                        <class>ebayenterprise_giftcard/container</class>
+                        <method>removeAllGiftCards</method>
+                    </ebayenterprise_giftcard_empty_container_cancel_order_create>
+                </observers>
+            </controller_action_postdispatch_adminhtml_sales_order_create_cancel>
+            <controller_action_postdispatch_adminhtml_sales_order_create_start>
+                <observers>
+                    <ebayenterprise_giftcard_empty_container_cancel_order_create>
+                        <type>model</type>
+                        <class>ebayenterprise_giftcard/container</class>
+                        <method>removeAllGiftCards</method>
+                    </ebayenterprise_giftcard_empty_container_cancel_order_create>
+                </observers>
+            </controller_action_postdispatch_adminhtml_sales_order_create_start>
         </events>
     </adminhtml>
     <default>


### PR DESCRIPTION
Empty the gift card session when creating an admin order is cancelled.
Prevents gift cards applied to the aborted order from applying to the
next order started by the same admin user.