### PR TITLE
ENF-68 Remove Repeated TAX In Confirmation Email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.41] - 2016-01-25
+### Fixed
+- Tax displayed twice in Order Confirmation Email
+
 ## [1.6.40] - 2016-01-21
 ### Fixed
 - Send the tokenized giftcard pan in order create request payload
@@ -416,6 +420,7 @@ All notable changes to this project will be documented in this file.
 - Gift card PIN is not submitted with the order
 - Product import not importing color descriptions
 
+[1.6.41]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.40...1.6.41
 [1.6.40]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.39...1.6.40
 [1.6.39]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.38...1.6.39
 [1.6.38]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.37...1.6.38

--- a/src/app/design/frontend/base/default/layout/ebayenterprise_tax.xml
+++ b/src/app/design/frontend/base/default/layout/ebayenterprise_tax.xml
@@ -17,6 +17,8 @@ http://opensource.org/licenses/osl-3.0.php
     <sales_email_order_items>
         <reference name="order_totals">
             <block type="ebayenterprise_tax/sales_order_tax" name="ebayenterprise_tax_total" />
+            <!-- Remove Vanilla Magento Tax, it will be replaced with ROM Tax -->
+            <remove name="tax"/>
         </reference>
     </sales_email_order_items>
 </layout>


### PR DESCRIPTION
Order confirmation email display tax twice for
orders where Giftcard cover the entired order totals.