### PR TITLE
Customer not notified when an unavailable quantity is added to the cart from configurable product page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.50] - 2016-03-07
+### Fixed
+- Customer not notified when an unavailable quantity is added to the cart from configurable product page
+
 ## [1.6.49] - 2016-03-07
 ### Fixed
 - Enterprise dependency should be the responsibility of the integrator
@@ -440,6 +444,7 @@ All notable changes to this project will be documented in this file.
 - Gift card PIN is not submitted with the order
 - Product import not importing color descriptions
 
+[1.6.50]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.49...1.6.50
 [1.6.49]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.48...1.6.49
 [1.6.48]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.47...1.6.48
 [1.6.47]: https://github.com/eBayEnterprise/magento-retail-order-management/compare/1.6.43...1.6.47

--- a/src/app/code/community/EbayEnterprise/Inventory/Helper/Data.php
+++ b/src/app/code/community/EbayEnterprise/Inventory/Helper/Data.php
@@ -272,11 +272,7 @@ class EbayEnterprise_Inventory_Helper_Data extends Mage_Core_Helper_Abstract imp
         $children = $item->getChildren();
         if ($children) {
             foreach ($children as $childItem) {
-                /** @var Mage_Catalog_Model_Product */
-                $product = $childItem->getProduct();
-                if ($product instanceof Mage_Catalog_Model_Product) {
-                    $skus[] = $product->getSku();
-                }
+                $skus[] = $childItem->getSku();
             }
         }
         return $skus;
@@ -290,17 +286,12 @@ class EbayEnterprise_Inventory_Helper_Data extends Mage_Core_Helper_Abstract imp
      */
     protected function getAllParentSkuFromItem(Mage_Core_Model_Abstract $item)
     {
-        /** @var Mage_Catalog_Model_Product */
-        $currentProduct = $item->getProduct();
-        /** @var Mage_Catalog_Model_Product[] */
-        $skus = [$currentProduct->getSku()];
+        $skus = [$item->getSku()];
         /** @var Mage_Sales_Model_Quote_Item */
         $parentItem = $item->getParentItem();
         if ($parentItem) {
-            /** @var Mage_Catalog_Model_Product */
-            $parentProduct = $parentItem->getProduct();
-            if ($currentProduct->getId() !== $parentProduct->getId()) {
-                $skus[] = $parentProduct->getSku();
+            if ($item->getProductId() !== $parentItem->getProductId()) {
+                $skus[] = $parentItem->getSku();
             }
         }
         return $skus;

--- a/src/app/code/community/EbayEnterprise/Inventory/Helper/Item/Selection.php
+++ b/src/app/code/community/EbayEnterprise/Inventory/Helper/Item/Selection.php
@@ -27,22 +27,20 @@ class EbayEnterprise_Inventory_Helper_Item_Selection implements EbayEnterprise_I
         return array_filter(
             $items,
             function ($item) {
-                return !$this->isExcludedParent($item) && $this->isStockManaged($item);
+                return !$this->isExcludedItem($item) && $this->isStockManaged($item);
             }
         );
     }
 
     /**
-     * returns true if the item is the parent of configurable/grouped products
+     * returns true if the item is the child of configurable/grouped product
      *
      * @param  Mage_Sales_Model_Quote_Item_Abstract
      * @return bool
      */
-    public function isExcludedParent(Mage_Sales_Model_Quote_Item_Abstract $item)
+    public function isExcludedItem(Mage_Sales_Model_Quote_Item_Abstract $item)
     {
-        $itemProductType = $item->getProduct()->getTypeId();
-        return $itemProductType === Mage_Catalog_Model_Product_Type::TYPE_CONFIGURABLE
-            || $itemProductType === Mage_Catalog_Model_Product_Type::TYPE_GROUPED;
+        return $item->getParentItem() instanceof Mage_Sales_Model_Quote_Item;
     }
 
     /**

--- a/src/app/code/community/EbayEnterprise/Inventory/Model/Quantity/Service.php
+++ b/src/app/code/community/EbayEnterprise/Inventory/Model/Quantity/Service.php
@@ -175,7 +175,7 @@ class EbayEnterprise_Inventory_Model_Quantity_Service implements EbayEnterprise_
     public function checkQuoteItemInventory(Mage_Sales_Model_Quote_Item $item)
     {
         // Only checking inventory that is managed and not a hidden parent item
-        if (!$this->_inventoryItemSelection->isExcludedParent($item) &&
+        if (!$this->_inventoryItemSelection->isExcludedItem($item) &&
             $this->_inventoryItemSelection->isStockManaged($item)) {
             // Determine if a stock message needs to be displayed
             if (!$this->isItemAvailable($item)) {

--- a/src/app/code/community/EbayEnterprise/Inventory/Model/Quantity/Unavailable/Item/Default.php
+++ b/src/app/code/community/EbayEnterprise/Inventory/Model/Quantity/Unavailable/Item/Default.php
@@ -151,9 +151,8 @@ class EbayEnterprise_Inventory_Model_Quantity_Unavailable_Item_Default
             $errorCode,
             $itemMessage
         );
-        $parentItem = $item->getParentItem();
-        if ($parentItem) {
-            $parentItem->addErrorInfo(
+        foreach ($item->getChildren() as $child) {
+            $child->addErrorInfo(
                 EbayEnterprise_Inventory_Model_Quantity_Service::ERROR_INFO_SOURCE,
                 $errorCode,
                 $itemMessage

--- a/src/app/code/community/EbayEnterprise/Inventory/Test/Helper/DataTest.php
+++ b/src/app/code/community/EbayEnterprise/Inventory/Test/Helper/DataTest.php
@@ -68,10 +68,8 @@ class EbayEnterprise_Inventory_Test_Helper_DataTest extends EbayEnterprise_Eb2cC
     {
         /** @var string */
         $childSku = 'ABCD1234';
-        /** @var Mage_Catalog_Model_Product */
-        $childProduct = Mage::getModel('catalog/product', ['sku' => $childSku]);
         /** @var Mage_Sales_Model_Quote_Item */
-        $children = Mage::getModel('sales/quote_item', ['product' => $childProduct]);
+        $children = Mage::getModel('sales/quote_item', ['sku' => $childSku]);
         /** @var Mage_Sales_Model_Quote_Item */
         $item = Mage::getModel('sales/quote_item');
         $item->addChild($children);
@@ -90,22 +88,18 @@ class EbayEnterprise_Inventory_Test_Helper_DataTest extends EbayEnterprise_Eb2cC
     public function testGetAllParentSkuFromItem()
     {
         /** @var string */
-        $parentASku = 'ABCD1234';
+        $childSku = 'ABCD1234';
         /** @var string */
-        $parentBSku = '1234ABCD';
-        /** @var Mage_Catalog_Model_Product */
-        $product = Mage::getModel('catalog/product', ['entity_id' => 34, 'sku' => $parentASku]);
-        /** @var Mage_Catalog_Model_Product */
-        $parentProduct = Mage::getModel('catalog/product', ['entity_id' => 55, 'sku' => $parentBSku]);
+        $parentSku = '1234ABCD';
         /** @var Mage_Sales_Model_Quote_Item */
-        $parent = Mage::getModel('sales/quote_item', ['product' => $parentProduct]);
+        $parent = Mage::getModel('sales/quote_item', ['product_id' => 34, 'sku' => $parentSku]);
         /** @var Mage_Sales_Model_Quote_Item */
-        $item = Mage::getModel('sales/quote_item', ['product' => $product]);
+        $item = Mage::getModel('sales/quote_item', ['product_id' => 55, 'sku' => $childSku]);
         $item->setParentItem($parent);
         /** @var EbayEnterprise_Inventory_Helper_Data */
         $helper = Mage::helper('ebayenterprise_inventory');
 
-        $this->assertSame([$parentASku, $parentBSku], EcomDev_Utils_Reflection::invokeRestrictedMethod($helper, 'getAllParentSkuFromItem', [$item]));
+        $this->assertSame([$childSku, $parentSku], EcomDev_Utils_Reflection::invokeRestrictedMethod($helper, 'getAllParentSkuFromItem', [$item]));
     }
 
     /**

--- a/src/app/code/community/EbayEnterprise/Inventory/Test/Helper/Item/SelectionTest.php
+++ b/src/app/code/community/EbayEnterprise/Inventory/Test/Helper/Item/SelectionTest.php
@@ -20,6 +20,7 @@ class EbayEnterprise_Inventory_Test_Helper_Item_SelectionTest extends EbayEnterp
      */
     public function testAddConfigurable()
     {
+        /** @var Mage_Sales_Model_Quote_Item $parent */
         $parent = Mage::getModel('sales/quote_item', [
             'product' => Mage::getModel('catalog/product', [
                 'stock_item' => $this->_getStockItemStub(true),
@@ -27,18 +28,18 @@ class EbayEnterprise_Inventory_Test_Helper_Item_SelectionTest extends EbayEnterp
                 'id' => 1
             ])
         ]);
+        /** @var Mage_Sales_Model_Quote_Item $single */
         $single = Mage::getModel('sales/quote_item', [
             'product' => Mage::getModel('catalog/product', [
                 'stock_item' => $this->_getStockItemStub(true),
-                'type_id' => 'simple',
-                'parent_item_id' => $parent->getId(),
-                'parent_item' => $parent
+                'type_id' => 'simple'
             ])
         ]);
+        $single->setParentItem($parent);
 
         $selection = Mage::helper('ebayenterprise_inventory/item_selection');
         $chosenItems = $selection->selectFrom([$single, $parent]);
-        $this->assertTrue(in_array($single, $chosenItems));
+        $this->assertTrue(in_array($parent, $chosenItems));
         $this->assertCount(1, $chosenItems);
     }
 
@@ -85,15 +86,14 @@ class EbayEnterprise_Inventory_Test_Helper_Item_SelectionTest extends EbayEnterp
         $single = Mage::getModel('sales/quote_item', [
             'product' => Mage::getModel('catalog/product', [
                 'stock_item' => $this->_getStockItemStub(true),
-                'type_id' => 'simple',
-                'parent_item_id' => $parent->getId(),
-                'parent_item' => $parent
+                'type_id' => 'simple'
             ])
         ]);
+        $single->setParentItem($parent);
 
         $selection = Mage::helper('ebayenterprise_inventory/item_selection');
         $chosenItems = $selection->selectFrom([$single, $parent]);
-        $this->assertTrue(in_array($single, $chosenItems));
+        $this->assertTrue(in_array($parent, $chosenItems));
         $this->assertCount(1, $chosenItems);
     }
 


### PR DESCRIPTION
NOTE: This change does not effect sites using 'simple configurable product' extension by organicinternet only those using default configurable products with the ROM extension inventory service.